### PR TITLE
Fix: ExceptionResponseDto 

### DIFF
--- a/src/main/java/Coordinate/coordikittyBE/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Coordinate/coordikittyBE/exception/GlobalExceptionHandler.java
@@ -13,6 +13,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CoordikittyException.class)
     public ResponseEntity<ExceptionResponseDto> handle(CoordikittyException ex){
         log.warn("Coordikitty exception [status={},errorCode={},message={}]", ex.getStatusCode(),ex.getErrorCode(),ex.getMessage());
-        return ResponseEntity.status(ex.getStatusCode()).body(new ExceptionResponseDto(ex.getErrorCode(),ex.getMessage()));
+        return ResponseEntity.status(ex.getStatusCode()).body(ExceptionResponseDto.of(ex.getErrorType()));
     }
 }


### PR DESCRIPTION
## 개요
exception/ExceptionResponseDto 에서 of method 사용으로 변경

## 내용
### 1. 기존 코드에서 Dto of method 미사용 중
- return ResponseEntity.status(ex.getStatusCode()).body(new ExceptionResponseDto(ex.getErrorCode(),ex.getMessage()));
### 2. 변경된 코드로 수정 제안
- return ResponseEntity.status(ex.getStatusCode()).body(ExceptionResponseDto.of(ex.getErrorType()));