### PR TITLE
CD-226 : Jwt 오류처리 구현

### DIFF
--- a/src/main/java/Coordinate/coordikittyBE/config/SecurityConfig.java
+++ b/src/main/java/Coordinate/coordikittyBE/config/SecurityConfig.java
@@ -1,46 +1,26 @@
 package Coordinate.coordikittyBE.config;
 
-import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationFilter;
-import Coordinate.coordikittyBE.domain.security.jwt.JwtExceptionFilter;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationEntryPoint;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
-@Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
+@Configuration
 public class SecurityConfig {
-    private final AuthenticationEntryPoint authenticationEntryPoint;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final JwtExceptionFilter jwtExceptionFilter;
+    private final ObjectMapper objectMapper;
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        return httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authz -> authz
-                        .requestMatchers(
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/auth/signUp",
-                                "/auth/signUp/dupCheck",
-                                "/auth/login",
-                                "/auth/token",
-                                "/auth/login/google",
-                                "/oauth2/authorization/google",
-                                "/post"
-                        ).permitAll()
-                        .anyRequest().authenticated()
-                )
-                .exceptionHandling(exception-> exception.authenticationEntryPoint(authenticationEntryPoint))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
-                .build();
+    public JwtAuthenticationEntryPoint authenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint(objectMapper);
     }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
 
 }

--- a/src/main/java/Coordinate/coordikittyBE/config/SecurityConfig.java
+++ b/src/main/java/Coordinate/coordikittyBE/config/SecurityConfig.java
@@ -1,12 +1,14 @@
 package Coordinate.coordikittyBE.config;
 
 import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationFilter;
+import Coordinate.coordikittyBE.domain.security.jwt.JwtExceptionFilter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -14,8 +16,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final AuthenticationEntryPoint authenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
+    private final JwtExceptionFilter jwtExceptionFilter;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
@@ -34,7 +37,9 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(exception-> exception.authenticationEntryPoint(authenticationEntryPoint))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/Coordinate/coordikittyBE/config/SecurityFilterConfig.java
+++ b/src/main/java/Coordinate/coordikittyBE/config/SecurityFilterConfig.java
@@ -1,0 +1,33 @@
+package Coordinate.coordikittyBE.config;
+
+import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationEntryPoint;
+import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationFilter;
+import Coordinate.coordikittyBE.domain.security.jwt.JwtExceptionFilter;
+import Coordinate.coordikittyBE.global.util.JwtHelper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@RequiredArgsConstructor
+@Configuration
+public class SecurityFilterConfig {
+    private final JwtHelper jwtHelper;
+    private final UserDetailsService userDetailsService;
+    private final ObjectMapper objectMapper;
+    @Bean
+    public JwtAuthenticationEntryPoint authenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public JwtExceptionFilter jwtExceptionFilter(){
+        return new JwtExceptionFilter(objectMapper);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(){
+        return new JwtAuthenticationFilter(jwtHelper, userDetailsService);
+    }
+}

--- a/src/main/java/Coordinate/coordikittyBE/config/SecurityFilterConfig.java
+++ b/src/main/java/Coordinate/coordikittyBE/config/SecurityFilterConfig.java
@@ -1,6 +1,5 @@
 package Coordinate.coordikittyBE.config;
 
-import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationEntryPoint;
 import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationFilter;
 import Coordinate.coordikittyBE.domain.security.jwt.JwtExceptionFilter;
 import Coordinate.coordikittyBE.global.util.JwtHelper;
@@ -16,10 +15,6 @@ public class SecurityFilterConfig {
     private final JwtHelper jwtHelper;
     private final UserDetailsService userDetailsService;
     private final ObjectMapper objectMapper;
-    @Bean
-    public JwtAuthenticationEntryPoint authenticationEntryPoint() {
-        return new JwtAuthenticationEntryPoint(objectMapper);
-    }
 
     @Bean
     public JwtExceptionFilter jwtExceptionFilter(){

--- a/src/main/java/Coordinate/coordikittyBE/config/WebSecurityConfig.java
+++ b/src/main/java/Coordinate/coordikittyBE/config/WebSecurityConfig.java
@@ -1,0 +1,46 @@
+package Coordinate.coordikittyBE.config;
+
+import Coordinate.coordikittyBE.domain.security.jwt.JwtAuthenticationFilter;
+import Coordinate.coordikittyBE.domain.security.jwt.JwtExceptionFilter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/auth/signUp",
+                                "/auth/signUp/dupCheck",
+                                "/auth/login",
+                                "/auth/token",
+                                "/auth/login/google",
+                                "/oauth2/authorization/google",
+                                "/post"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(exception-> exception.authenticationEntryPoint(authenticationEntryPoint))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+                .build();
+    }
+
+}

--- a/src/main/java/Coordinate/coordikittyBE/domain/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/Coordinate/coordikittyBE/domain/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package Coordinate.coordikittyBE.domain.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.warn("Unauthorized : {}", authException.getMessage());
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        objectMapper.writeValue(response.getWriter(), null);
+    }
+}

--- a/src/main/java/Coordinate/coordikittyBE/domain/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Coordinate/coordikittyBE/domain/security/jwt/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package Coordinate.coordikittyBE.domain.security.jwt;
 
 import java.io.IOException;
 import java.util.Date;
-import java.util.UUID;
 
 import Coordinate.coordikittyBE.exception.CoordikittyException;
 import Coordinate.coordikittyBE.exception.ErrorType;
@@ -18,11 +17,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtHelper jwtHelper;

--- a/src/main/java/Coordinate/coordikittyBE/domain/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/Coordinate/coordikittyBE/domain/security/jwt/JwtExceptionFilter.java
@@ -1,0 +1,38 @@
+package Coordinate.coordikittyBE.domain.security.jwt;
+
+import Coordinate.coordikittyBE.exception.ErrorType;
+import Coordinate.coordikittyBE.global.common.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        response.setCharacterEncoding("utf-8");
+
+        log.info("jwtExceptionFilter 실행");
+        try{
+            chain.doFilter(request, response);
+        } catch (ExpiredJwtException e){
+            log.info("expiredJwtEcxeption");
+            response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorType.TOKEN_EXPIRED)));
+        } catch (JwtException e){
+            log.info("JwtException");
+            response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorType.TOKEN_NOT_FOUND)));
+        }
+    }
+}

--- a/src/main/java/Coordinate/coordikittyBE/exception/ErrorType.java
+++ b/src/main/java/Coordinate/coordikittyBE/exception/ErrorType.java
@@ -10,9 +10,8 @@ public enum ErrorType {
 
     MEMBER_NOT_FOUND("AUTH-001", "해당 유저를 찾을 수 없습니다.", 401),
     INVALID_TOKEN("AUTH-002", "유효하지 않은 토큰입니다.", 401),
-    TOKEN_PAYLOAD_EXTRACTION_FAILURE("AUTH-003", "토큰 페이로드 추출에 실패했습니다", 401),
     TOKEN_NOT_FOUND("AUTH-004", "토큰을 찾을 수 없습니다.", 401),
-    REFRESH_TOKEN_ALREADY_EXIST("AUTH-005", "리프레시토큰이 이미 존재합니다.", 400),
+    TOKEN_EXPIRED("AUTH-005", "리프레시토큰이 이미 존재합니다.", 401),
     INVALID_USER_ID("AUTH-006", "잘못된 유저 ID 입니다.", 401),
 
     MISSING_REQUIRED_VALUE_ERROR("COMMON-001", "필수 요청값이 누락되었습니다.", 400),

--- a/src/main/java/Coordinate/coordikittyBE/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Coordinate/coordikittyBE/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package Coordinate.coordikittyBE.exception;
 
-import Coordinate.coordikittyBE.global.common.response.ExceptionResponse;
+import Coordinate.coordikittyBE.global.common.response.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
     private final Logger log = LoggerFactory.getLogger(getClass());
     @ExceptionHandler(CoordikittyException.class)
-    public ResponseEntity<ExceptionResponse> handle(CoordikittyException ex){
+    public ResponseEntity<ErrorResponse> handle(CoordikittyException ex){
         log.warn("Coordikitty exception [status={},errorCode={},message={}]", ex.getStatusCode(),ex.getErrorCode(),ex.getMessage());
-        return ResponseEntity.status(ex.getStatusCode()).body(ExceptionResponse.of(ex.getErrorType()));
+        return ResponseEntity.status(ex.getStatusCode()).body(ErrorResponse.of(ex.getErrorType()));
     }
 }

--- a/src/main/java/Coordinate/coordikittyBE/global/common/response/ErrorResponse.java
+++ b/src/main/java/Coordinate/coordikittyBE/global/common/response/ErrorResponse.java
@@ -1,0 +1,9 @@
+package Coordinate.coordikittyBE.global.common.response;
+
+import Coordinate.coordikittyBE.exception.ErrorType;
+
+public record ErrorResponse(String errorCode, String message) {
+    public static ErrorResponse of(ErrorType errorType) {
+        return new ErrorResponse(errorType.getErrorCode(), errorType.getMessage());
+    }
+}

--- a/src/main/java/Coordinate/coordikittyBE/global/common/response/ExceptionResponse.java
+++ b/src/main/java/Coordinate/coordikittyBE/global/common/response/ExceptionResponse.java
@@ -1,9 +1,0 @@
-package Coordinate.coordikittyBE.global.common.response;
-
-import Coordinate.coordikittyBE.exception.ErrorType;
-
-public record ExceptionResponse(String errorCode, String message) {
-    public static ExceptionResponse of(ErrorType errorType) {
-        return new ExceptionResponse(errorType.getErrorCode(), errorType.getMessage());
-    }
-}


### PR DESCRIPTION
## 개요
우리가 현재 구현해둔 jwt 필터에서의 에러처리는 잘못된 방식이다.  
클라이언트 -> 필터 -> 디스패쳐 서블릿 -> 인터셉터 -> 컨트롤러' 순으로 동작하고 다시 클라이언트로 갈때도 역순으로 작동한다. 그러므로 필터에서 오류가 생기면 컨트롤러에서 작동하는 글로벌엑셉션핸들러가 작동하지 않는다.
아래의 사진을 참고할 것.
![image](https://github.com/user-attachments/assets/59f04651-a4c2-42ae-8ac4-60dff5840a39)

## 구현내용
- jwt필터에서 발생하는 오류처리를 위해 필터를 구현하고, 엔트리 포인트도 만들었다.
- 시큐리티config들을 분리하였다.
